### PR TITLE
fix: fix defaultMapStateToProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const storeShape = PropTypes.shape({
 });
 
 function defaultMapStateToProps(state, props) {
-  return { ...state, ...props };
+  return { ...props, ...state };
 }
 
 function getNamespace(parentNamespace, namespace) {


### PR DESCRIPTION
props 与 state 覆盖顺序有误，具体可参考 react-redux：
https://github.com/reactjs/react-redux/blob/master/src/connect/mergeProps.js#L4