### PR TITLE
feat: refactor react-refect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const storeShape = PropTypes.shape({
 });
 
 function defaultMapStateToProps(state, props) {
-  return { ...state, ...props };
+  return { ...props, ...state };
 }
 
 function getNamespace(parentNamespace, namespace) {


### PR DESCRIPTION
@jasonHzq @camsong 

对 refect 提出一些想法与改进，希望通过最小的改动来提升 refect 的灵活性与开发体验。

- [x] 去除 refect componentWillMount 时才向全局添加 state、render 以及 task
  - 由于 state 是动态新增的，可能会引发父级组件不必要的 reRender
  - 父级组件不易获取子组件的数据，需要借助 lodash.get
  - redux 通过 combineReducers，在 createStore 时完成整个 store State 的初始化，refect 其实可以在 refectRoot 中完成 configureRefect

- [x] state 完全打平，避免由于组件树较深，造成数据嵌套较深的问题。
```javascript
// 嵌套
{
  pickers: {
    page: { ... },
    userPicker: { ... },
    repoPicker: { ... },
  }
}
// 打平
{
  pickers: { page: { ... }, }
  userPicker: { ... },
  repoPicker: { ... },
}
```

- [x] action 中 mount、unmount 传入参数与组件 props 使用 getFinalProps 统一，解决之前 action.mount 中无法获取 store 中的值。

- [x] 更方便地拿到全局 action，默认包含在 getFinalProps 中，在组件的 props、action.mount 与 unmount时均可获取所有 action

- [ ] effect.watch 一般放在 action.mount 中，当组件多次 mount 后，watch 会重复监听执行，必须手动消除监听。参考 saga，建议是在 refectRoot 内完成 watch，可能需要修改 refect。